### PR TITLE
add typescript declaration file

### DIFF
--- a/dist/lenis.d.ts
+++ b/dist/lenis.d.ts
@@ -1,0 +1,70 @@
+export default class Lenis {
+    constructor({ duration, easing, smooth, direction, wrapper, content, }?: {
+        duration?: number;
+        easing?: (t: any) => number;
+        smooth?: boolean;
+        direction?: string;
+        wrapper?: Window & typeof globalThis;
+        content?: HTMLElement;
+    }, ...args: any[]);
+    wrapperNode: Window & typeof globalThis;
+    contentNode: HTMLElement;
+    duration: number;
+    easing: (t: any) => number;
+    smooth: boolean;
+    direction: string;
+    wrapperHeight: any;
+    wrapperWidth: any;
+    wrapperObserver: ResizeObserver;
+    contentHeight: number;
+    contentWidth: number;
+    contentObserver: ResizeObserver;
+    targetScroll: any;
+    scroll: any;
+    lastScroll: any;
+    animate: Animate;
+    virtualScroll: any;
+    get scrollProperty(): string;
+    start(): void;
+    stopped: boolean;
+    stop(): void;
+    destroy(): void;
+    onWindowResize: () => void;
+    onWrapperResize: ([entry]: [any]) => void;
+    onContentResize: ([entry]: [any]) => void;
+    get limit(): number;
+    onVirtualScroll: ({ deltaY, originalEvent }: {
+        deltaY: any;
+        originalEvent: any;
+    }) => void;
+    raf(now: any): void;
+    now: any;
+    isScrolling: boolean;
+    get velocity(): number;
+    setScroll(value: any): void;
+    onScroll: () => void;
+    notify(): void;
+    scrollTo(target: any, { offset, immediate, duration, easing, }?: {
+        offset?: number;
+        immediate?: boolean;
+        duration?: number;
+        easing?: (t: any) => number;
+    }): void;
+}
+declare class Animate {
+    to(target: any, { duration, easing, ...keys }?: {
+        duration?: number;
+        easing?: (t: any) => any;
+    }): void;
+    target: any;
+    fromKeys: {};
+    toKeys: {};
+    keys: string[];
+    duration: number;
+    easing: (t: any) => any;
+    currentTime: any;
+    isRunning: boolean;
+    raf(deltaTime: any): void;
+    get progress(): number;
+}
+export {};

--- a/dist/lenis.d.ts
+++ b/dist/lenis.d.ts
@@ -1,18 +1,18 @@
 export default class Lenis {
     constructor({ duration, easing, smooth, direction, wrapper, content, }?: {
         duration?: number;
-        easing?: (t: any) => number;
+        easing?: (t: number) => number;
         smooth?: boolean;
-        direction?: string;
-        wrapper?: Window & typeof globalThis;
+        direction?: "vertical" | "horizontal";
+        wrapper?: Window | HTMLElement;
         content?: HTMLElement;
     }, ...args: any[]);
-    wrapperNode: Window & typeof globalThis;
+    wrapperNode: HTMLElement | Window;
     contentNode: HTMLElement;
     duration: number;
-    easing: (t: any) => number;
+    easing: (t: number) => number;
     smooth: boolean;
-    direction: string;
+    direction: "vertical" | "horizontal";
     wrapperHeight: any;
     wrapperWidth: any;
     wrapperObserver: ResizeObserver;
@@ -48,7 +48,7 @@ export default class Lenis {
         offset?: number;
         immediate?: boolean;
         duration?: number;
-        easing?: (t: any) => number;
+        easing?: (t: number) => number;
     }): void;
 }
 declare class Animate {

--- a/dist/maths.d.ts
+++ b/dist/maths.d.ts
@@ -1,0 +1,4 @@
+export function clamp(min: any, input: any, max: any): number;
+export function mapRange(in_min: any, in_max: any, input: any, out_min: any, out_max: any): any;
+export function lerp(start: any, end: any, amt: any): number;
+export function truncate(value: any, decimals: any): number;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "size": "size-limit",
     "clean": "rimraf dist && rimraf bundled",
     "build": "npm run clean && npm run build:light && npm run build:bundle && npm run build:types",
-    "build:types": "tsc --allowJs -d --emitDeclarationOnly --declarationDir dist ./src/*.js",
+    "build:types": "tsc --allowJs -d --emitDeclarationOnly --declarationDir dist --removeComments ./src/*.js",
     "build:light": "microbundle",
     "build:bundle": "microbundle build -i src/lenis.js --format umd --compress --no-sourcemap --no-pkg-main --external none --output ./bundled --name 'Lenis'",
     "build:website": "vite build",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "dist/lenis.js",
   "umd:main": "dist/lenis.umd.js",
   "module": "dist/lenis.mjs",
+  "types": "dist/lenis.d.ts",
   "exports": {
     "require": "./dist/lenis.js",
     "default": "./dist/lenis.modern.mjs"
@@ -24,6 +25,7 @@
     "rimraf": "^3.0.2",
     "size-limit": "^8.1.0",
     "stats.js": "^0.17.0",
+    "typescript": "^4.8.3",
     "vite": "^3.1.0"
   },
   "dependencies": {
@@ -39,7 +41,8 @@
     "dev": "microbundle watch -i src/lenis.js --format umd --compress --no-sourcemap --no-pkg-main --external none --output ./bundled --name 'Lenis' & npm run dev:website --prefix ./website",
     "size": "size-limit",
     "clean": "rimraf dist && rimraf bundled",
-    "build": "npm run clean && npm run build:light && npm run build:bundle",
+    "build": "npm run clean && npm run build:light && npm run build:bundle && npm run build:types",
+    "build:types": "tsc --allowJs -d --emitDeclarationOnly --declarationDir dist ./src/*.js",
     "build:light": "microbundle",
     "build:bundle": "microbundle build -i src/lenis.js --format umd --compress --no-sourcemap --no-pkg-main --external none --output ./bundled --name 'Lenis'",
     "build:website": "vite build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   size-limit: ^8.1.0
   stats.js: ^0.17.0
   tiny-emitter: ^2.1.0
+  typescript: ^4.8.3
   virtual-scroll: ^2.2.1
   vite: ^3.1.0
 
@@ -28,6 +29,7 @@ devDependencies:
   rimraf: 3.0.2
   size-limit: 8.1.0
   stats.js: 0.17.0
+  typescript: 4.8.3
   vite: 3.1.0
 
 packages:
@@ -3187,13 +3189,13 @@ packages:
       rollup-plugin-bundle-size: 1.0.3
       rollup-plugin-postcss: 4.0.2_postcss@8.4.16
       rollup-plugin-terser: 7.0.2_rollup@2.79.0
-      rollup-plugin-typescript2: 0.32.1_id3sp2lbl4kx3dskm7teaj32um
+      rollup-plugin-typescript2: 0.32.1_ihkqvyh37tzxtjmovjyy2yrv7m
       rollup-plugin-visualizer: 5.8.1_rollup@2.79.0
       sade: 1.8.1
       terser: 5.15.0
       tiny-glob: 0.2.9
       tslib: 2.4.0
-      typescript: 4.8.2
+      typescript: 4.8.3
     transitivePeerDependencies:
       - '@types/babel__core'
       - supports-color
@@ -4040,7 +4042,7 @@ packages:
       terser: 5.15.0
     dev: true
 
-  /rollup-plugin-typescript2/0.32.1_id3sp2lbl4kx3dskm7teaj32um:
+  /rollup-plugin-typescript2/0.32.1_ihkqvyh37tzxtjmovjyy2yrv7m:
     resolution: {integrity: sha512-RanO8bp1WbeMv0bVlgcbsFNCn+Y3rX7wF97SQLDxf0fMLsg0B/QFF005t4AsGUcDgF3aKJHoqt4JF2xVaABeKw==}
     peerDependencies:
       rollup: '>=1.26.3'
@@ -4052,7 +4054,7 @@ packages:
       resolve: 1.22.1
       rollup: 2.79.0
       tslib: 2.4.0
-      typescript: 4.8.2
+      typescript: 4.8.3
     dev: true
 
   /rollup-plugin-visualizer/5.8.1_rollup@2.79.0:
@@ -4431,8 +4433,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /typescript/4.8.2:
-    resolution: {integrity: sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==}
+  /typescript/4.8.3:
+    resolution: {integrity: sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/src/lenis.js
+++ b/src/lenis.js
@@ -55,6 +55,20 @@ class Animate {
 }
 
 export default class Lenis extends EventEmitter {
+  /**
+   * @typedef {(t: number) => number} EasingFunction
+   * @typedef {'vertical' | 'horizontal'} Direction
+   *
+   * @typedef LenisOptions
+   * @property {number} [duration]
+   * @property {EasingFunction} [easing]
+   * @property {boolean} [smooth]
+   * @property {Direction} [direction]
+   * @property {Window | HTMLElement} [wrapper]
+   * @property {HTMLElement} [content]
+   *
+   * @param {LenisOptions}
+   */
   constructor({
     duration = 1.2,
     easing = (t) => (t === 1 ? 1 : 1 - Math.pow(2, -10 * t)), //expo.out


### PR DESCRIPTION
👋 Hi! Thanks for starting this super cool project. I'm looking to use this in a personal TypeScript project and thought this might be a helpful addition.

This PR adds a process to automatically generate TypeScript declaration files.

**Changes**
* adds `typescript` dev dependency
* adds a new script named `build:types` that generates a `lenis.d.ts` file containing type definitions using the emitDeclarationOnly option ([reference](https://www.typescriptlang.org/tsconfig#emitDeclarationOnly))
* adds `"types"` property in package.json ([reference](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html))
* adds "ts" badge to detail page on npm package registry ([reference](https://github.blog/changelog/2020-12-16-npm-displays-packages-with-bundled-typescript-declarations/))

**Future Improvements**
* To make the automated types more detailed, `JSDoc` type annotation comments could be added to the source code.
  For example:
  ```javascript
  /** @type {(t: number) => number} */
  this.easing = easing;
  ```
* It would also improve VS Code Intellisense suggestions within JavaScript files ([reference](https://code.visualstudio.com/Docs/languages/javascript#_jsdoc-support))

**Alternatives**
* If this doesn't feel like a good direction for the project, an alternative would be to add this to the [DefinitelyTyped](https://definitelytyped.github.io/) project instead