### PR TITLE
Fixes a codrops demo link

### DIFF
--- a/website/content/projects.js
+++ b/website/content/projects.js
@@ -27,7 +27,7 @@ export const projects = [
   {
     title: 'How to Animate SVG Shapes on Scroll',
     source: 'Codrops',
-    href: 'https://getrepeat.io',
+    href: 'https://tympanus.net/Tutorials/OnScrollPathAnimations/',
   },
   {
     title: 'Dragonfly',


### PR DESCRIPTION
Fixed the projects.js with the missing codrops demo link (was before getrepeat.io - a repeated link)