### PR TITLE
feat: add badge to quick view of the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![LENIS](https://assets.studiofreight.com/lenis/header.png)](https://github.com/studio-freight/lenis)
 
+[![npm version](https://img.shields.io/badge/dynamic/json?color=blue&label=npm&prefix=v&query=version&suffix=%20&url=https%3A%2F%2Fraw.githubusercontent.com%2Fstudio-freight%2Flenis%2Fmain%2Fpackage.json)](https://www.npmjs.com/package/@studio-freight/lenis)
+
 ## Introduction
 
 🚧 Still in WIP, API might change with new releases 🚧


### PR DESCRIPTION
Hi, this is irrelevant but I saw that you didnt have the common badges used to identify the npm version and license. I didn't see the licence file so I just added the npm version badge. This is taking the version automatically from package json, so it will be updated every time that this file change.