### PR TITLE
Round Animate.to target

### DIFF
--- a/src/animate.js
+++ b/src/animate.js
@@ -38,9 +38,10 @@ export class Animate {
 
   // Set up the animation from a starting value to an ending value
   // with optional parameters for lerping, duration, easing, and onUpdate callback
+  // to value is rounded to ensure proper animation completion detection when using lerping
   fromTo(from, to, { lerp = 0.1, duration = 1, easing = (t) => t, onUpdate }) {
     this.from = this.value = from
-    this.to = to
+    this.to = Math.round(to)
     this.lerp = lerp
     this.duration = duration
     this.easing = easing


### PR DESCRIPTION
Fix never ending lerping when `to` is not an integer thus never passing the `Math.round(this.value) === this.to` check to determine animation completion. 

Fix this issue https://github.com/studio-freight/lenis/issues/168

This approach rounds the `to` value directly when its set from the `fromTo` method as it should be more efficient than rounding it at every `advance` call to compare values. 