### PR TITLE
fix lerp normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studio-freight/lenis",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Lenis is a smooth scroll library to normalize the scrolling experience across devices",
   "files": [
     "dist",

--- a/src/animate.js
+++ b/src/animate.js
@@ -1,4 +1,4 @@
-import { clamp, lerp } from './maths'
+import {clamp, lerp} from './maths';
 
 // Animate class to handle value animations with lerping or easing
 export class Animate {
@@ -9,7 +9,8 @@ export class Animate {
     let completed = false
 
     if (this.lerp) {
-      this.value = lerp(this.value, this.to, this.lerp)
+      const fps = 60
+      this.value = lerp(this.value, this.to, this.lerp * deltaTime * fps)
       if (Math.round(this.value) === this.to) {
         this.value = this.to
         completed = true


### PR DESCRIPTION
## Context
A recent update introduced lerping scroll destination, which is great to get a natural scrolling behaviour.

## Problem
This implementation is missing fps normalization, meaning a 120hz screen will scroll twice as fast compared to a 60hz screen.

## Proposal
This small fix normalizes lerp ratio based on a 60hz refresh rate.