### PR TITLE
fix: add types field to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "module": "dist/lenis.mjs",
   "types": "dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/lenis.js",
     "default": "./dist/lenis.modern.mjs"
   },


### PR DESCRIPTION
Hello,

In modern environments (`nodenext`, `bundler`) the types won't be used because they are not specified in `exports` field. Read about it more here: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

fixes #174