### PR TITLE
feat: add support for custom normalize-wheel handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export default class Lenis {
    * @typedef {(t: number) => number} EasingFunction
    * @typedef {'vertical' | 'horizontal'} Orientation
    * @typedef {'vertical' | 'horizontal' | 'both'} GestureOrientation
+   * @typedef {(e: WheelEvent) => {deltaX: number, deltaY:number}} NormalizeWheelHandler
    *
    * @typedef LenisOptions
    * @property {Window | HTMLElement} [wrapper]
@@ -43,7 +44,7 @@ export default class Lenis {
    * @property {GestureOrientation} [gestureOrientation]
    * @property {number} [touchMultiplier]
    * @property {number} [wheelMultiplier]
-   * @property {boolean} [normalizeWheel]
+   * @property {boolean | NormalizeWheelHandler} [normalizeWheel]
    * @property {boolean} [autoResize]
    *
    * @param {LenisOptions}

--- a/src/virtual-scroll.js
+++ b/src/virtual-scroll.js
@@ -104,7 +104,11 @@ export class VirtualScroll {
   onWheel = (event) => {
     let { deltaX, deltaY } = event
 
-    if (this.normalizeWheel) {
+    if (typeof this.normalizeWheel === 'function') {
+      const normalized = this.normalizeWheel(event)
+      deltaX = normalized.deltaX
+      deltaY = normalized.deltaY
+    } else if (this.normalizeWheel) {
       deltaX = clamp(-100, deltaX, 100)
       deltaY = clamp(-100, deltaY, 100)
     }


### PR DESCRIPTION
Hi,
i wrote this PR to enable a custom normalize-wheel handler, so the end user can choose how normalize the wheel.
For example using the [normalize-wheel package](https://www.npmjs.com/package/normalize-wheel) 

This is an example
```
import { gsap } from 'gsap'
import normalizeWheel from 'normalize-wheel'

const calculate = (value: number, intent:number, inertial: number) => {
  const direction = value > 0 ? 1 : -1
  const clamped = gsap.utils.clamp(0, 1, Math.abs(value / 100))
  const inertiaFactor = Math.abs(value) >= 100 ? intent : inertial

  return {
    delta: direction * clamped * inertiaFactor,
    direction
  }
}

export function getNormalizeWheel (event: WheelEvent, intent = 0.02, inertial = 0.04) {
  const { pixelX, pixelY } = normalizeWheel(event)
  const { delta: deltaX, direction: directionX } = calculate(pixelX, intent, inertial)
  const { delta: deltaY, direction: directionY } = calculate(pixelY, intent, inertial)

  return {
    deltaX,
    deltaY,
    directionX,
    directionY,
    event
  }
}

```


Thanks for this amazing library!