### PR TITLE
fix: options types are not exported

### DIFF
--- a/packages/lenis/src/index.js
+++ b/packages/lenis/src/index.js
@@ -5,6 +5,8 @@ import { Emitter } from './emitter'
 import { clamp, modulo } from './maths'
 import { VirtualScroll } from './virtual-scroll'
 
+export * from "./types"
+
 // Technical explanation
 // - listen to 'wheel' events
 // - prevent 'wheel' event to prevent scroll
@@ -20,33 +22,7 @@ export default class Lenis {
   // isLocked = same as isStopped but enabled/disabled when scroll reaches target
 
   /**
-   * @typedef {(t: number) => number} EasingFunction
-   * @typedef {'vertical' | 'horizontal'} Orientation
-   * @typedef {'vertical' | 'horizontal' | 'both'} GestureOrientation
-   *
-   * @typedef LenisOptions
-   * @property {Window | HTMLElement} [wrapper]
-   * @property {HTMLElement} [content]
-   * @property {Window | HTMLElement} [wheelEventsTarget] // deprecated
-   * @property {Window | HTMLElement} [eventsTarget]
-   * @property {boolean} [smoothWheel]
-   * @property {boolean} [smoothTouch]
-   * @property {boolean} [syncTouch]
-   * @property {number} [syncTouchLerp]
-  //  * @property {number} [__iosNoInertiaSyncTouchLerp]
-   * @property {number} [touchInertiaMultiplier]
-   * @property {number} [duration]
-   * @property {EasingFunction} [easing]
-   * @property {number} [lerp]
-   * @property {boolean} [infinite]
-   * @property {Orientation} [orientation]
-   * @property {GestureOrientation} [gestureOrientation]
-   * @property {number} [touchMultiplier]
-   * @property {number} [wheelMultiplier]
-   * @property {boolean} [normalizeWheel] 
-   * @property {boolean} [autoResize]
-   *
-   * @param {LenisOptions}
+   * @param {import('./types').LenisOptions} options
    */
   constructor({
     wrapper = window,
@@ -63,8 +39,8 @@ export default class Lenis {
     easing = (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
     lerp = !duration && 0.1,
     infinite = false,
-    orientation = 'vertical', // vertical, horizontal
     gestureOrientation = 'vertical', // vertical, horizontal, both
+    orientation = 'vertical', // vertical, horizontal
     touchMultiplier = 1,
     wheelMultiplier = 1,
     normalizeWheel = false, // deprecated

--- a/packages/lenis/src/types.ts
+++ b/packages/lenis/src/types.ts
@@ -1,0 +1,26 @@
+export type EasingFunction = (t: number) => number;
+export type Orientation = 'vertical' | 'horizontal';
+export type GestureOrientation = 'vertical' | 'horizontal' | 'both';
+
+export type LenisOptions = {
+  wrapper?: Window | HTMLElement;
+  content?: HTMLElement;
+  wheelEventsTarget?: Window | HTMLElement;
+  eventsTarget?: Window | HTMLElement;
+  smoothWheel?: boolean;
+  smoothTouch?: boolean;
+  syncTouch?: boolean;
+  syncTouchLerp?: number;
+  // __iosNoInertiaSyncTouchLerp?: number;
+  touchInertiaMultiplier?: number;
+  duration?: number;
+  easing?: EasingFunction;
+  lerp?: number;
+  infinite?: boolean;
+  gestureOrientation?: Orientation;
+  orientation?: Orientation;
+  touchMultiplier?: number;
+  wheelMultiplier?: number;
+  normalizeWheel?: boolean;
+  autoResize?: boolean;
+};


### PR DESCRIPTION
Currently the only thing exported was Lenis class, if you are working in a typescript environment and you need the option types you ends with something like this.

```ts
import Lenis from "@studio-freight/lenis";

type LenisOptions = ConstructorParameters<typeof Lenis>[0];
```

Also if you are working in js with JSDoc and you are trying to get the type, it is imposible.

```js
/**
* @type {import('@studio-freight/lenis').LenisOptions} this doesn't exist, so it ends with an any type
*/
const options = {...}
```

I explore other options with jsdoc, to be able to expose the LenisOptions like:
  - [tsd-jsdoc](https://github.com/englercj/tsd-jsdoc)

But I dificulties trying to make it work and beeing compatible with the current export (of Lenis class) and code.

I could continue exploring this options if you thing that is the best approuch, but the most convinent way to do that right now is just having a .ts file with the interface that we need what to export.