### PR TITLE
fix: add lenis-svelte to the list of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ prevent touch events only
 - [locomotive-scroll](https://github.com/locomotivemtl/locomotive-scroll) by [Locomotive](https://locomotive.ca/)
 - [vue-lenis](https://github.com/zeokku/vue-lenis) by [ZEOKKU](https://zeokku.com/)
 - [nuxt-lenis](https://www.npmjs.com/package/nuxt-lenis) by [Milkshake Studio](https://milkshake.studio/)
+- [lenis-svelte](https://www.npmjs.com/package/lenis-svelte) by [DaniAcu](https://github.com/DaniAcu)
 
 <br>
 


### PR DESCRIPTION
I'm started working on svelte, and I notice lenis doesn't have a wrapper for svelte like it does for nuxt and vue. So I create the package.

If you are okay with adding this package here it will be really helpful for future svelte developer that are trying to use this awesome library in their projects.