### PR TITLE
Update README.md

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -23,7 +23,7 @@ function Component() {
   })
 
   return (
-    <ReactLenis root options={{ autoRaf: true }}>
+    <ReactLenis root>
       { /* content */ }
     </ReactLenis>
   )
@@ -69,7 +69,7 @@ function Component() {
   }, [])
   
   return (
-    <ReactLenis ref={lenisRef}>
+    <ReactLenis options={{ autoRaf: false }} ref={lenisRef}>
       { /* content */ }
     </ReactLenis>
   )
@@ -98,7 +98,7 @@ function Component() {
   }, [])
   
   return (
-    <ReactLenis ref={lenisRef}>
+    <ReactLenis options={{ autoRaf: false }} ref={lenisRef}>
       { /* content */ }
     </ReactLenis>
   )
@@ -126,7 +126,7 @@ function Component() {
 
 
   return (
-    <ReactLenis ref={lenisRef}>
+    <ReactLenis options={{ autoRaf: false }} ref={lenisRef}>
       { /* content */ }
     </ReactLenis>
   )


### PR DESCRIPTION
Hey! I spotted an issue on the docs

It seems like the ReactLenis `provider.tsx` changed the `autoRaf` prop default value from `false` to `true` at some point and the docs doesn't reflect that change. On the custom raf examples it's not explicitly disabling the `autoRaf`, duplicating the calls to `lenis.raf`.

PD: Loving the new [darkroom.engineering](https://darkroom.engineering/) website btw ;)