### PR TITLE
docs(lenis/react): fix wrong function name within the Framer Motion integration example

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -115,7 +115,7 @@ function Component() {
   const lenisRef = useRef()
 
   useEffect(() => {
-    function raf(time) {
+    function update(time) {
       lenisRef.current?.lenis?.raf(time)
     }
 


### PR DESCRIPTION
A small one