### PR TITLE
Fixed type errors in the React example

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -107,15 +107,17 @@ function Component() {
 
 ### Framer Motion integration:
 ```jsx
-import { ReactLenis } from 'lenis/react'
+import { ReactLenis } from 'lenis/react';
+import type { LenisRef } from 'lenis/react';
 import { cancelFrame, frame } from 'framer-motion';
 import { useEffect, useRef } from 'react';
 
 function Component() {
-  const lenisRef = useRef()
+  const lenisRef = useRef<LenisRef>(null)
 
   useEffect(() => {
-    function update(time) {
+    function update(data: { timestamp: number }) {
+      const time = data.timestamp
       lenisRef.current?.lenis?.raf(time)
     }
 


### PR DESCRIPTION
It's rather a small add :)
I imported `LenisRef` and modified the existing example.

`raf` in Lenis expects a number:
`* @param time The time in ms from an external clock like `requestAnimationFrame` or Tempus`

In the framer-motion package, `update` method expects first arg with type [FrameData](https://github.com/motiondivision/motion/blob/8ca78c00b6ee537c47085170f58530a1b96ea5c3/packages/framer-motion/src/frameloop/types.ts#L33-L37) 
We may hardcode the same and update the useEffect like this and access the time
```tsx
interface FrameData {
  delta: number
  timestamp: number
  isProcessing: boolean
}

export function Lenis() {
  const lenisRef = useRef<LenisRef>(null)

  useEffect(() => {
    function update(data: FrameData) {
      lenisRef.current?.lenis?.raf(data.timestamp)
    }

    frame.update(update, true)

    return () => cancelFrame(update)
  }, [])

  return (
    <ReactLenis options={{ autoRaf: false }} ref={lenisRef}>
      { /* content */ }
    </ReactLenis>
  )
}
```

Or just define the timestamp type to make it simpler
```tsx
export function Lenis() {
  const lenisRef = useRef<LenisRef>(null)

  useEffect(() => {
    function update(data: { timestamp: number }) {
      const time = data.timestamp
      lenisRef.current?.lenis?.raf(time)
    }

    frame.update(update, true)

    return () => cancelFrame(update)
  }, [])

  return (
    <ReactLenis options={{ autoRaf: false }} ref={lenisRef}>
      { /* content */ }
    </ReactLenis>
  )
}
```
