### PR TITLE
Proposal for controlling the snap scroll distance

### DIFF
--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -60,6 +60,8 @@ export class Snap {
       easing,
       duration,
       velocityThreshold = 1,
+      scrollThresholdPercentage = 0,
+      scrollThreshold = 0,
       debounce: debounceDelay = 0,
       onSnapStart,
       onSnapComplete,
@@ -71,6 +73,8 @@ export class Snap {
       easing,
       duration,
       velocityThreshold,
+      scrollThresholdPercentage,
+      scrollThreshold,
       debounce: debounceDelay,
       onSnapStart,
       onSnapComplete,
@@ -225,7 +229,33 @@ export class Snap {
     if (nextSnap === undefined) nextSnap = snaps[snaps.length - 1]!
     const distanceToNextSnap = Math.abs(scroll - nextSnap.value)
 
-    const snap = distanceToPrevSnap < distanceToNextSnap ? prevSnap : nextSnap
+    let snap = distanceToPrevSnap < distanceToNextSnap ? prevSnap : nextSnap
+    const hasScrollThresholdPercentage =
+      this.options.scrollThresholdPercentage &&
+      this.options.scrollThresholdPercentage > 0
+    const hasScrollThresholdPixels =
+      this.options.scrollThreshold && this.options.scrollThreshold > 0
+    if (hasScrollThresholdPercentage || hasScrollThresholdPixels) {
+      const snapDifference = nextSnap.value - prevSnap.value
+      const threshold = hasScrollThresholdPercentage
+        ? snapDifference * (this.options.scrollThresholdPercentage as number)
+        : (this.options.scrollThreshold as number)
+      if (this.lenis.direction === 1) {
+        // Down
+        if (scroll - prevSnap.value >= threshold) {
+          snap = nextSnap
+        } else {
+          snap = prevSnap
+        }
+      } else {
+        // Up
+        if (nextSnap.value - scroll >= threshold) {
+          snap = prevSnap
+        } else {
+          snap = nextSnap
+        }
+      }
+    }
 
     const distance = Math.abs(scroll - snap.value)
 

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -30,6 +30,14 @@ export type SnapOptions = {
    */
   velocityThreshold?: number
   /**
+   * The scroll threshold in percentage to trigger a snap between the previous and next snapping points.
+   */
+  scrollThresholdPercentage?: number
+  /**
+   * The scroll threshold in pixels to trigger a snap between the previous and next snapping points.
+   */
+  scrollThreshold?: number
+  /**
    * The debounce delay (in ms) to prevent snapping too often
    */
   debounce?: number


### PR DESCRIPTION
When using both Lenis and the Snap package I noticed that there was no way to really control the distance that the user needed to scroll from the starting point of a snap, in order to trigger the snap to the next snapping point. I also found that at least one other person (with people apparently watching the comment) had the same need: https://github.com/darkroomengineering/lenis/issues/12#issuecomment-2604472145

This proposal adds two properties to the Snap instance options, `scrollDistancePercentage` and `scrollDistance` that allow you to control either the percentage needed to scroll or the exact pixels to scroll in order to trigger the snap. The percentage calculates a pixel value based on the difference between the `prevSnap.value` and the `nextSnap.value`. So if the distance between the snapping points is 500px, and the percentage is set to 20%, you would need to scroll 100px to trigger the snap.

Didn't see any tests in place to update or add to, but let me know what you think of the proposal and if I should change and or add anything.

Love the library. :)