### PR TITLE
Corrected typo 'Lenis is Use' to 'Lenis in Use' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Read our [Manifesto](https://github.com/darkroomengineering/lenis/blob/main/MANI
 - [Troubleshooting](#troubleshooting)
 - [Tutorials](#tutorials)
 - [Plugins](#plugins)
-- [Lenis is Use](#lenis-in-use)
+- [Lenis in Use](#lenis-in-use)
 - [License](#license)
 
 <br/>


### PR DESCRIPTION
This PR corrects a small typo in the README heading and anchor link:
- Changed `Lenis is Use to Lenis in Use`

Thank you for this amazing tool, 
Its my first open source contribution - Cheers!
