### PR TITLE
Don't check for lenis instance existence in PROD

### DIFF
--- a/packages/vue/src/use-lenis.ts
+++ b/packages/vue/src/use-lenis.ts
@@ -29,7 +29,7 @@ export function useLenis(callback?: ScrollCallback, priority = 0) {
     // Wait two ticks to make sure the lenis instance is mounted
     nextTick(() => {
       nextTick(() => {
-        if (!lenis.value) {
+        if (!lenis.value && import.meta.env.DEV) {
           console.warn(
             'No lenis instance found, either mount a root lenis instance or wrap your component in a lenis provider'
           )


### PR DESCRIPTION
Fix for https://github.com/darkroomengineering/lenis/issues/473

Introduced a check to tell if we are in dev mode - otherwise don't show a warning about lenis not being initialized yet.