### PR TITLE
Render root as child

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lenis",
-  "version": "1.3.9-dev.0",
+  "version": "1.3.9-dev.1",
   "description": "How smooth scroll should be",
   "type": "module",
   "sideEffects": false,
@@ -39,8 +39,9 @@
     "version:minor": "npm version minor --force --no-git-tag-version",
     "version:major": "npm version major --force --no-git-tag-version",
     "postversion": "pnpm build && pnpm readme",
-    "publish:main": "npm publish",
-    "publish:dev": "npm publish --tag dev"
+     "publish:dev": "npm publish --tag dev",
+    "publish:main": "npm publish"
+   
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lenis",
-  "version": "1.3.8",
+  "version": "1.3.9-dev.0",
   "description": "How smooth scroll should be",
   "type": "module",
   "sideEffects": false,

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -30,15 +30,13 @@ export const ReactLenis = forwardRef<LenisRef, LenisProps>(
       children,
       root = false,
       options = {},
-      className,
       autoRaf = true,
-      style,
-      props,
+      ...props
     }: LenisProps,
     ref
   ) => {
-    const wrapperRef = useRef<HTMLDivElement | null>(null)
-    const contentRef = useRef<HTMLDivElement | null>(null)
+    const wrapperRef = useRef<HTMLDivElement>(null)
+    const contentRef = useRef<HTMLDivElement>(null)
 
     const [lenis, setLenis] = useState<Lenis | undefined>(undefined)
 
@@ -57,10 +55,11 @@ export const ReactLenis = forwardRef<LenisRef, LenisProps>(
     useEffect(() => {
       const lenis = new Lenis({
         ...options,
-        ...(!root && {
-          wrapper: wrapperRef.current!,
-          content: contentRef.current!,
-        }),
+        ...(wrapperRef.current &&
+          contentRef.current && {
+            wrapper: wrapperRef.current!,
+            content: contentRef.current!,
+          }),
         autoRaf: options?.autoRaf ?? autoRaf, // this is to avoid breaking the autoRaf prop if it's still used (require breaking change)
       })
 
@@ -70,7 +69,7 @@ export const ReactLenis = forwardRef<LenisRef, LenisProps>(
         lenis.destroy()
         setLenis(undefined)
       }
-    }, [root, JSON.stringify(options)])
+    }, [root, JSON.stringify({ ...options, wrapper: null, content: null })])
 
     // Handle callbacks
     const callbacksRefs = useRef<
@@ -123,14 +122,16 @@ export const ReactLenis = forwardRef<LenisRef, LenisProps>(
       }
     }, [lenis])
 
+    if (!children) return null
+
     return (
       <LenisContext.Provider
         value={{ lenis: lenis!, addCallback, removeCallback }}
       >
-        {root ? (
+        {root && root !== 'asChild' ? (
           children
         ) : (
-          <div ref={wrapperRef} className={className} style={style} {...props}>
+          <div ref={wrapperRef} {...props}>
             <div ref={contentRef}>{children}</div>
           </div>
         )}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -30,9 +30,21 @@ export type LenisProps = {
    */
   children?: ReactNode
   /**
+   * Additional className for the wrapper div
+   *
+   * When `root` is `false` or `root` is `asChild`, this will be applied to the wrapper div
+   */
+  className?: string
+  /**
+   * Additional style for the content div
+   *
+   * When `root` is `false` or `root` is `asChild`, this will be applied to the content div
+   */
+  style?: React.CSSProperties
+  /**
    * Additional props for the wrapper div
    *
-   * When `root` is `false`, this will be applied to the wrapper div
+   * When `root` is `false` or `root` is `asChild`, this will be applied to the wrapper div
    */
   props?: Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className'>
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,6 +1,6 @@
 import type Lenis from 'lenis'
 import type { LenisOptions, ScrollCallback } from 'lenis'
-import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from 'react'
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 
 export type LenisContextValue = {
   lenis: Lenis
@@ -11,9 +11,10 @@ export type LenisContextValue = {
 export type LenisProps = {
   /**
    * Setup a global instance of Lenis
+   * if `asChild`, the component will render wrapper and content divs
    * @default false
    */
-  root?: boolean
+  root?: boolean | 'asChild'
   /**
    * Lenis options
    */
@@ -29,18 +30,6 @@ export type LenisProps = {
    */
   children?: ReactNode
   /**
-   * Class name for the wrapper div
-   *
-   * When `root` is `false`, this will be applied to the wrapper div
-   */
-  className?: string
-  /**
-   * Style for the wrapper div
-   *
-   * When `root` is `false`, this will be applied to the wrapper div
-   */
-  style?: CSSProperties
-  /**
    * Additional props for the wrapper div
    *
    * When `root` is `false`, this will be applied to the wrapper div
@@ -52,13 +41,13 @@ export type LenisRef = {
   /**
    * The wrapper div element
    *
-   * Will only be defined if `root` is `false`
+   * Will only be defined if `root` is `false` or `root` is `asChild`
    */
   wrapper: HTMLDivElement | null
   /**
    * The content div element
    *
-   * Will only be defined if `root` is `false`
+   * Will only be defined if `root` is `false` or `root` is `asChild`
    */
   content: HTMLDivElement | null
   /**

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -8,7 +8,7 @@ export type LenisContextValue = {
   removeCallback: (callback: ScrollCallback) => void
 }
 
-export type LenisProps = {
+export type LenisProps = ComponentPropsWithoutRef<'div'> & {
   /**
    * Setup a global instance of Lenis
    * if `asChild`, the component will render wrapper and content divs
@@ -29,24 +29,6 @@ export type LenisProps = {
    * Children
    */
   children?: ReactNode
-  /**
-   * Additional className for the wrapper div
-   *
-   * When `root` is `false` or `root` is `asChild`, this will be applied to the wrapper div
-   */
-  className?: string
-  /**
-   * Additional style for the content div
-   *
-   * When `root` is `false` or `root` is `asChild`, this will be applied to the content div
-   */
-  style?: React.CSSProperties
-  /**
-   * Additional props for the wrapper div
-   *
-   * When `root` is `false` or `root` is `asChild`, this will be applied to the wrapper div
-   */
-  props?: Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className'>
 }
 
 export type LenisRef = {

--- a/playground/react/app.tsx
+++ b/playground/react/app.tsx
@@ -30,7 +30,12 @@ function App() {
   return (
     <>
       {/* <ReactLenis root /> */}
-      <ReactLenis className="wrapper" root="asChild" ref={lenisRef}>
+      <ReactLenis
+        className="wrapper"
+        root="asChild"
+        sfsdfdsf="dssdfs"
+        ref={lenisRef}
+      >
         {lorem}
       </ReactLenis>
     </>

--- a/playground/react/app.tsx
+++ b/playground/react/app.tsx
@@ -1,15 +1,19 @@
-import { ReactLenis, useLenis } from 'lenis/react'
+import { ReactLenis, useLenis, type LenisRef } from 'lenis/react'
 import { LoremIpsum } from 'lorem-ipsum'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 function App() {
   const [lorem] = useState(() => new LoremIpsum().generateParagraphs(200))
 
   const lenis = useLenis((lenis) => {
-    // console.log('lenis in callback', lenis)
+    console.log('lenis in callback', lenis)
   })
 
-  const lenisRef = useRef()
+  const lenisRef = useRef<LenisRef>(null)
+
+  useEffect(() => {
+    console.log('lenis ref', lenisRef.current)
+  }, [lenisRef])
 
   // useEffect(() => {
   //   console.log('lenis ref', lenisRef.current)
@@ -26,12 +30,7 @@ function App() {
   return (
     <>
       {/* <ReactLenis root /> */}
-      <ReactLenis
-        className="wrapper"
-        // root
-        ref={lenisRef}
-        style={{ height: '100vh', overflowY: 'auto' }}
-      >
+      <ReactLenis className="wrapper" root="asChild" ref={lenisRef}>
         {lorem}
       </ReactLenis>
     </>

--- a/playground/react/style.css
+++ b/playground/react/style.css
@@ -1,4 +1,28 @@
-/* .lenis {
-  height: 100vh;
-  overflow-y: auto;
-} */
+html:not(.lenis) {
+  body,
+  & {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+  body {
+    position: fixed;
+    overscroll-behavior-y: none;
+    overscroll-behavior-x: none;
+  }
+
+  .lenis {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    overflow-y: scroll;
+    -ms-scroll-chaining: none;
+    overscroll-behavior: contain;
+    background: #0b41cd;
+  }
+}

--- a/playground/www/layouts/Layout.astro
+++ b/playground/www/layouts/Layout.astro
@@ -78,6 +78,7 @@ const { title } = Astro.props
     height: 3rem;
     display: flex;
     gap: 2px;
+    z-index: 1;
   }
 
   a {


### PR DESCRIPTION
This PR allows to render a nested `<ReactLenis/>` component as `root` meaning that its instance will be considered as global and shared globally even thought it's not targeting `html` element.
This is experimental still.