### PR TITLE
Add Motion Integration for vue to README

### DIFF
--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -145,6 +145,33 @@ onMounted(() => {
 </template>
 ```
 
+### Motion Integration
+```vue
+<script setup>
+import { VueLenis } from 'lenis/vue'
+import { cancelFrame, frame } from 'motion-v'
+import { onMounted, onUnmounted, ref } from 'vue'
+
+const lenisRef = ref()
+
+function update({ timestamp }) {
+  lenisRef.value?.lenis?.raf(timestamp)
+}
+
+onMounted(() => {
+  frame.update(update, true)
+})
+
+onUnmounted(() => {
+  cancelFrame(update)
+})
+</script>
+
+<template>
+  <VueLenis ref="lenisRef" root :options="{ autoRaf: false }">
+  <!-- content -->
+</template>
+```
 
 <br/>
 


### PR DESCRIPTION
As Motion (formerly framer motion) now supports Vue. I've added a example to integrate lenis with framer motion.