### PR TITLE
fix: handle anchor and internal page click navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lenis",
-  "version": "1.3.18",
+  "version": "1.3.19-dev.0",
   "description": "How smooth scroll should be",
   "type": "module",
   "sideEffects": false,

--- a/packages/core/src/lenis.ts
+++ b/packages/core/src/lenis.ts
@@ -121,7 +121,7 @@ export class Lenis {
     naiveDimensions = __experimental__naiveDimensions,
     stopInertiaOnNavigate = false,
   }: LenisOptions = {}) {
-    // Set version
+    // Set version (deprecated)
     window.lenisVersion = version
 
     if (!window.lenis) {
@@ -132,6 +132,10 @@ export class Lenis {
 
     if (orientation === 'horizontal') {
       window.lenis.horizontal = true
+    }
+
+    if (syncTouch === true) {
+      window.lenis.touch = true
     }
 
     // Check if wrapper is <html>, fallback to window

--- a/packages/core/src/lenis.ts
+++ b/packages/core/src/lenis.ts
@@ -334,37 +334,46 @@ export class Lenis {
     const path = event.composedPath()
 
     // filter anchor elements (elements with a valid href attribute)
-    const anchorElements = path.filter(
-      (node) => node instanceof HTMLAnchorElement && node.getAttribute('href')
+    const linkElements = path.filter(
+      (node) => node instanceof HTMLAnchorElement && node.href
     ) as HTMLAnchorElement[]
+    const linkElementsUrls = linkElements.map(
+      (element) => new URL(element.href)
+    )
+
+    const currentUrl = new URL(window.location.href)
 
     if (this.options.anchors) {
-      const anchor = anchorElements.find((node) =>
-        node.getAttribute('href')?.includes('#')
+      const anchorElementUrl = linkElementsUrls.find(
+        (targetUrl) =>
+          currentUrl.host === targetUrl.host &&
+          currentUrl.pathname === targetUrl.pathname &&
+          targetUrl.hash
       )
-      if (anchor) {
-        const href = anchor.getAttribute('href')
 
-        if (href) {
-          const options =
-            typeof this.options.anchors === 'object' && this.options.anchors
-              ? this.options.anchors
-              : undefined
+      if (anchorElementUrl) {
+        const options =
+          typeof this.options.anchors === 'object' && this.options.anchors
+            ? this.options.anchors
+            : undefined
 
-          const target = `#${href.split('#')[1]}`
+        const target = `#${anchorElementUrl.hash.split('#')[1]}`
 
-          this.scrollTo(target, options)
-        }
+        this.scrollTo(target, options)
+        return
       }
     }
 
     if (this.options.stopInertiaOnNavigate) {
-      const internalLink = anchorElements.find(
-        (node) => node.host === window.location.host
+      const hasPageLinkElementUrl = linkElementsUrls.some(
+        (targetUrl) =>
+          currentUrl.host === targetUrl.host &&
+          currentUrl.pathname !== targetUrl.pathname
       )
 
-      if (internalLink) {
+      if (hasPageLinkElementUrl) {
         this.reset()
+        return
       }
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -237,6 +237,7 @@ declare global {
       version?: string
       horizontal?: boolean
       snap?: boolean
+      touch?: boolean
     }
   }
 }

--- a/playground/core/test.ts
+++ b/playground/core/test.ts
@@ -39,12 +39,12 @@ const lenis = new Lenis({
   smoothWheel: true,
   autoRaf: true,
   anchors: {
-    onStart: () => {
-      console.log('onStart')
-    },
-    onComplete: () => {
-      console.log('onComplete')
-    },
+    // onStart: () => {
+    //   console.log('onStart')
+    // },
+    // onComplete: () => {
+    //   console.log('onComplete')
+    // },
   },
   autoToggle: true,
   allowNestedScroll: true,

--- a/playground/www/pages/core.astro
+++ b/playground/www/pages/core.astro
@@ -43,7 +43,7 @@ import Layout from '../layouts/Layout.astro'
       <a href="#about"> <span>about</span></a>
       <a href="#work"> <span>work</span></a>
       <a href="#contact"> <span>contact</span></a>
-      <a href="#a"> <span>void</span></a>
+      <a href="/react#a"> <span>void</span></a>
       <a
         href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement"
         target="_blank"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 4.4.2(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(terser@5.46.0)
       '@astrojs/vue':
         specifier: ^5.0.6
-        version: 5.1.4(astro@5.17.1)(terser@5.46.0)(vue@3.5.27)
+        version: 5.1.4(@nuxt/kit@4.3.0)(astro@5.17.1)(terser@5.46.0)(vue@3.5.27)
       '@types/react':
         specifier: ^19.0.7
         version: 19.2.11
@@ -267,7 +267,7 @@ packages:
       - supports-color
     dev: false
 
-  /@astrojs/vue@5.1.4(astro@5.17.1)(terser@5.46.0)(vue@3.5.27):
+  /@astrojs/vue@5.1.4(@nuxt/kit@4.3.0)(astro@5.17.1)(terser@5.46.0)(vue@3.5.27):
     resolution: {integrity: sha512-srE+3tgSnGG4FVr7Bs9JAgLcUAg1mtGrbBFdwlj++Y05Awwlc967WCcmOK6rnxQ6q5PcK5+WL2x2tKoWh5SN7A==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
     peerDependencies:
@@ -279,9 +279,10 @@ packages:
       '@vue/compiler-sfc': 3.5.27
       astro: 5.17.1(terser@5.46.0)(typescript@5.9.3)
       vite: 6.4.1(terser@5.46.0)
-      vite-plugin-vue-devtools: 7.7.9(vite@6.4.1)(vue@3.5.27)
+      vite-plugin-vue-devtools: 7.7.9(@nuxt/kit@4.3.0)(vite@6.4.1)(vue@3.5.27)
       vue: 3.5.27(typescript@5.9.3)
     transitivePeerDependencies:
+      - '@nuxt/kit'
       - '@types/node'
       - jiti
       - less
@@ -8694,7 +8695,7 @@ packages:
       vscode-uri: 3.1.0
     dev: false
 
-  /vite-plugin-inspect@0.8.9(vite@6.4.1):
+  /vite-plugin-inspect@0.8.9(@nuxt/kit@4.3.0)(vite@6.4.1):
     resolution: {integrity: sha512-22/8qn+LYonzibb1VeFZmISdVao5kC22jmEKm24vfFE8siEn47EpVcCLYMv6iKOYMJfjSvSJfueOwcFCkUnV3A==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -8705,6 +8706,7 @@ packages:
         optional: true
     dependencies:
       '@antfu/utils': 0.7.10
+      '@nuxt/kit': 4.3.0(magicast@0.5.1)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
       debug: 4.4.3
       error-stack-parser-es: 0.1.5
@@ -8744,7 +8746,7 @@ packages:
       - supports-color
     dev: false
 
-  /vite-plugin-vue-devtools@7.7.9(vite@6.4.1)(vue@3.5.27):
+  /vite-plugin-vue-devtools@7.7.9(@nuxt/kit@4.3.0)(vite@6.4.1)(vue@3.5.27):
     resolution: {integrity: sha512-08DvePf663SxqLFJeMVNW537zzVyakp9KIrI2K7lwgaTqA5R/ydN/N2K8dgZO34tg/Qmw0ch84fOKoBtCEdcGg==}
     engines: {node: '>=v14.21.3'}
     peerDependencies:
@@ -8756,9 +8758,10 @@ packages:
       execa: 9.6.1
       sirv: 3.0.2
       vite: 6.4.1(terser@5.46.0)
-      vite-plugin-inspect: 0.8.9(vite@6.4.1)
+      vite-plugin-inspect: 0.8.9(@nuxt/kit@4.3.0)(vite@6.4.1)
       vite-plugin-vue-inspector: 5.3.2(vite@6.4.1)
     transitivePeerDependencies:
+      - '@nuxt/kit'
       - rollup
       - supports-color
       - vue


### PR DESCRIPTION
## Summary
- Separates click handling logic for same-page anchor links (`anchors` option) from internal page navigation (`stopInertiaOnNavigate`)
- Same-page anchor clicks are now properly detected by comparing host + pathname + hash, and handled via `scrollTo` without triggering inertia reset
- Internal page links (same host, different pathname) correctly trigger `reset()` via `stopInertiaOnNavigate`

Closes #505

## Test plan
- [x] Click same-page anchor links (`#section`) — should smooth scroll without resetting inertia
- [x] Click internal page links (`/about`) — should reset inertia when `stopInertiaOnNavigate` is enabled
- [x] Click external links — should not trigger any Lenis behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)