### PR TITLE
fix(scrollTo): handle browser scroll restoration timing for immediate option

### DIFF
--- a/packages/core/src/lenis.ts
+++ b/packages/core/src/lenis.ts
@@ -34,6 +34,7 @@ export class Lenis {
   private _preventNextNativeScrollEvent = false
   private _resetVelocityTimeout: ReturnType<typeof setTimeout> | null = null
   private _rafId: number | null = null
+  private _savedScrollRestoration: ScrollRestoration | null = null
 
   /**
    * Whether or not the user is touching the screen
@@ -120,6 +121,7 @@ export class Lenis {
     __experimental__naiveDimensions = false,
     naiveDimensions = __experimental__naiveDimensions,
     stopInertiaOnNavigate = false,
+    preventScrollRestoration = false,
   }: LenisOptions = {}) {
     // Set version (deprecated)
     window.lenisVersion = version
@@ -177,6 +179,12 @@ export class Lenis {
       allowNestedScroll,
       naiveDimensions,
       stopInertiaOnNavigate,
+      preventScrollRestoration,
+    }
+
+    if (preventScrollRestoration && this.options.wrapper === window) {
+      this._savedScrollRestoration = history.scrollRestoration
+      history.scrollRestoration = 'manual'
     }
 
     // Setup dimensions instance
@@ -252,6 +260,10 @@ export class Lenis {
     this.dimensions.destroy()
 
     this.cleanUpClassName()
+
+    if (this._savedScrollRestoration !== null) {
+      history.scrollRestoration = this._savedScrollRestoration
+    }
 
     if (this._rafId) {
       cancelAnimationFrame(this._rafId)
@@ -796,7 +808,17 @@ export class Lenis {
       onComplete?.(this)
       this.userData = {}
 
+      // Re-apply scroll position after browser scroll restoration which may
+      // fire asynchronously after page load and override the position we set.
+      const scrollTarget = this.scroll
       requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (this.actualScroll !== scrollTarget) {
+            this.animatedScroll = this.targetScroll = scrollTarget
+            this.setScroll(scrollTarget)
+            this.preventNextNativeScrollEvent()
+          }
+        })
         this.dispatchScrollendEvent()
       })
       return

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -228,6 +228,13 @@ export type LenisOptions = {
    * @default false
    */
   stopInertiaOnNavigate?: boolean
+  /**
+   * If `true`, Lenis will set `history.scrollRestoration = 'manual'` to prevent
+   * browser scroll restoration from interfering with `scrollTo({ immediate: true })`
+   * on page load.
+   * @default false
+   */
+  preventScrollRestoration?: boolean
 }
 
 declare global {


### PR DESCRIPTION
## Summary
Fixes #443

## Problem
When `scrollTo(target, { immediate: true })` is called on page load, Chrome's scroll restoration fires asynchronously after Lenis initialization, overwriting the scroll position set by Lenis.

**Timeline of the bug:**
1. Page loads
2. Lenis initializes
3. `scrollTo(0, { immediate: true })` executes → scroll = 0
4. Browser scroll restoration fires (delayed) → scroll = previous position
5. Lenis work is overwritten

## Solution
This adds two mechanisms to fix the issue:

1. **`preventScrollRestoration` option** (new, opt-in) — Sets `history.scrollRestoration = 'manual'` to prevent browser scroll restoration entirely. Restored on `destroy()`.

2. **Double-rAF guard in `scrollTo`** — When `immediate: true`, re-checks and re-applies the scroll position two animation frames later if the browser has overridden it. This works even without the new option.

### Usage
```js
const lenis = new Lenis({
  autoRaf: true,
  preventScrollRestoration: true,
})

lenis.scrollTo(0, { immediate: true })
```

### Testing
- [x] Chrome: Verified scroll position is set correctly after reload
- [x] Firefox: Existing behavior preserved
- [x] Safari: Tested on macOS
- [x] immediate: false still works as expected
- [x] onComplete callback fires correctly
- [x] Build passes with no errors

Made-with: Cursor