### PR TITLE
fix(core): don't scroll while dragging iOS text-selection handles

### DIFF
--- a/packages/core/src/lenis.ts
+++ b/packages/core/src/lenis.ts
@@ -34,6 +34,7 @@ export class Lenis {
   private _preventNextNativeScrollEvent = false
   private _resetVelocityTimeout: ReturnType<typeof setTimeout> | null = null
   private _rafId: number | null = null
+  private _isDraggingSelection = false // true while a touch is dragging an iOS selection handle
 
   /**
    * Whether or not the user is touching the screen
@@ -391,6 +392,34 @@ export class Lenis {
     }
   }
 
+  // iOS renders text-selection handles at the start and end points of the
+  // selection. A touch starting within a handle-sized radius of either point is
+  // the user grabbing a handle, not scrolling.
+  private isTouchOnSelectionHandle(event: TouchEvent) {
+    const selection = window.getSelection()
+    if (!selection || selection.isCollapsed || selection.rangeCount === 0)
+      return false
+
+    const touch = event.targetTouches[0] ?? event.changedTouches[0]
+    if (!touch) return false
+
+    const rects = selection.getRangeAt(0).getClientRects()
+    if (rects.length === 0) return false
+
+    const first = rects[0]!
+    const last = rects[rects.length - 1]!
+    const HANDLE_RADIUS = 40 // px — handles are large, finger-sized touch targets
+
+    const nearStart =
+      Math.hypot(touch.clientX - first.left, touch.clientY - first.top) <=
+      HANDLE_RADIUS
+    const nearEnd =
+      Math.hypot(touch.clientX - last.right, touch.clientY - last.bottom) <=
+      HANDLE_RADIUS
+
+    return nearStart || nearEnd
+  }
+
   private onVirtualScroll = (data: VirtualScrollData) => {
     if (
       typeof this.options.virtualScroll === 'function' &&
@@ -409,6 +438,21 @@ export class Lenis {
 
     const isTouch = event.type.includes('touch')
     const isWheel = event.type.includes('wheel')
+
+    const isIos = /(iPad|iPhone|iPod)/g.test(navigator.userAgent)
+    // If the touch grabbed an iOS text-selection handle, let the OS adjust the
+    // selection instead of scrolling. Latched on touchstart, held until touchend.
+    if (isTouch && isIos) {
+      if (event.type === 'touchstart') {
+        this._isDraggingSelection = this.isTouchOnSelectionHandle(
+          event as TouchEvent
+        )
+      }
+      if (this._isDraggingSelection) {
+        if (event.type === 'touchend') this._isDraggingSelection = false
+        return
+      }
+    }
 
     this.isTouching = event.type === 'touchstart' || event.type === 'touchmove'
 

--- a/packages/core/src/lenis.ts
+++ b/packages/core/src/lenis.ts
@@ -41,6 +41,10 @@ export class Lenis {
    */
   isTouching?: boolean
   /**
+   * Whether or not the device is running iOS
+   */
+  isIos: boolean
+  /**
    * The time in ms since the lenis instance was created
    */
   time = 0
@@ -138,6 +142,8 @@ export class Lenis {
     if (syncTouch === true) {
       window.lenis.touch = true
     }
+
+    this.isIos = /(iPad|iPhone|iPod)/g.test(navigator.userAgent)
 
     // Check if wrapper is <html>, fallback to window
     if (!wrapper || wrapper === document.documentElement) {
@@ -439,10 +445,9 @@ export class Lenis {
     const isTouch = event.type.includes('touch')
     const isWheel = event.type.includes('wheel')
 
-    const isIos = /(iPad|iPhone|iPod)/g.test(navigator.userAgent)
     // If the touch grabbed an iOS text-selection handle, let the OS adjust the
     // selection instead of scrolling. Latched on touchstart, held until touchend.
-    if (isTouch && isIos) {
+    if (isTouch && this.isIos) {
       if (event.type === 'touchstart') {
         this._isDraggingSelection = this.isTouchOnSelectionHandle(
           event as TouchEvent

--- a/playground/touch-debug/test.ts
+++ b/playground/touch-debug/test.ts
@@ -1,0 +1,48 @@
+import { LoremIpsum } from 'lorem-ipsum'
+
+// No Lenis here — we only want to observe whether dragging a native selection
+// handle dispatches touch events to the page.
+
+// Fill the page so there's something to scroll and to select.
+document.querySelector('#content')!.innerHTML =
+  new LoremIpsum().generateParagraphs(30)
+
+// --- touch HUD ---------------------------------------------------------------
+const hud = document.querySelector<HTMLElement>('#hud')!
+const flash = document.querySelector<HTMLElement>('#flash')!
+const dot = document.querySelector<HTMLElement>('#dot')!
+const counts = { touchstart: 0, touchmove: 0, touchend: 0 }
+const log: string[] = []
+
+function render(type: string, t?: Touch) {
+  const sel = window.getSelection()
+  const selText = sel && !sel.isCollapsed ? sel.toString().slice(0, 30) : '—'
+  log.unshift(
+    `${type.padEnd(10)} x=${t ? Math.round(t.clientX) : '-'} y=${t ? Math.round(t.clientY) : '-'}`
+  )
+  log.length = 12
+  hud.textContent =
+    `start:${counts.touchstart}  move:${counts.touchmove}  end:${counts.touchend}\n` +
+    `selection: ${selText}\n` +
+    `userAgent: ${navigator.userAgent.slice(0, 60)}\n\n` +
+    log.join('\n')
+}
+
+function onTouch(e: TouchEvent) {
+  counts[e.type as keyof typeof counts]++
+  const t = e.touches[0] ?? e.changedTouches[0]
+  if (e.type === 'touchmove') {
+    flash.style.opacity = '0.35'
+    setTimeout(() => (flash.style.opacity = '0'), 50)
+  }
+  if (t) {
+    dot.style.opacity = e.type === 'touchend' ? '0' : '1'
+    dot.style.transform = `translate(${t.clientX}px, ${t.clientY}px)`
+  }
+  render(e.type, t)
+}
+
+// passive so we observe without interfering with native selection/scroll
+for (const type of ['touchstart', 'touchmove', 'touchend'] as const) {
+  document.addEventListener(type, onTouch, { passive: true })
+}

--- a/playground/www/layouts/Layout.astro
+++ b/playground/www/layouts/Layout.astro
@@ -36,6 +36,7 @@ const { title } = Astro.props
       <a href="/vue">Vue</a>
       <a href="/horizontal">Horizontal</a>
       <a href="/infinite">Infinite</a>
+      <a href="/touch-debug">Touch</a>
     </nav>
     <slot />
   </body>

--- a/playground/www/pages/touch-debug.astro
+++ b/playground/www/pages/touch-debug.astro
@@ -1,0 +1,69 @@
+---
+import Layout from '../layouts/Layout.astro'
+---
+
+<Layout title="Touch / selection debug">
+  <div id="hud">waiting for touch…</div>
+  <div id="flash"></div>
+  <div id="dot"></div>
+
+  <main>
+    <h1>Touch / selection debug</h1>
+    <p>
+      Long-press the text below to select, then drag the selection handles.
+      Watch the HUD: if <code>touchmove</code> keeps counting while you drag a
+      handle, this device forwards selection drags to the page (iOS). If it
+      stays put, it doesn't (Android).
+    </p>
+    <div id="content"></div>
+  </main>
+
+  <script src="../../touch-debug/test.ts"></script>
+</Layout>
+
+<style>
+  main {
+    width: min(70ch, 90vw);
+    margin: 6rem auto 40vh;
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
+  #hud {
+    position: fixed;
+    top: 0;
+    right: 0;
+    background: #111;
+    color: #0f0;
+    font: 12px/1.4 monospace;
+    padding: 8px;
+    white-space: pre;
+    z-index: 10;
+    max-height: 45vh;
+    overflow: auto;
+  }
+
+  #flash {
+    position: fixed;
+    inset: 0;
+    background: red;
+    opacity: 0;
+    pointer-events: none;
+    z-index: 5;
+    transition: opacity 0.05s;
+  }
+
+  #dot {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 24px;
+    height: 24px;
+    margin: -12px 0 0 -12px;
+    border: 2px solid lime;
+    border-radius: 50%;
+    pointer-events: none;
+    z-index: 6;
+    opacity: 0;
+  }
+</style>


### PR DESCRIPTION
Closes #523

## Problem

On iOS, dragging the text-selection handles scrolls the page instead of adjusting the selection.

## Root cause

Selection handles are rendered differently per platform:

- **Android**: handles are native overlays drawn *above* the webview — dragging them never dispatches touch events to the page, so Lenis never sees them.
- **iOS**: the handles dispatch real `touchmove` events into the page. Lenis reads any non-zero-delta `touchmove` as a scroll gesture, calls `preventDefault()` and scrolls — hijacking the selection drag.

(Confirmed empirically with the `/touch-debug` playground page added here.)

## Approach

Gate on `this.isIos` (only platform that forwards these events), and when a touch begins within a handle-sized radius of the current selection's start/end points, latch the gesture as a selection drag and skip scroll handling until `touchend`.

Inert on Android (no events fire there to test).

## Notes / open questions

- Detection is geometric (selection rect corners + a 40px radius). It's the only signal available at `touchstart`; behavioral signals (`selectionchange`) lag the first sub-character moves and let an initial scroll through. The 40px radius is a tuning knob.
- Needs verification on real iOS Safari across versions.

## Playground

Adds a Lenis-free `/touch-debug` page (nav: **Touch**) that logs raw touch events, used to confirm the iOS-vs-Android difference.