### PR TITLE
fix(core): resolve anchor targets with CSS-special-char ids

### DIFF
--- a/packages/core/src/lenis.ts
+++ b/packages/core/src/lenis.ts
@@ -371,7 +371,9 @@ export class Lenis {
             ? this.options.anchors
             : undefined
 
-        const target = `#${anchorElementUrl.hash.split('#')[1]}`
+        // hash is URL-encoded (e.g. `#footnote-%E2%80%A0`); decode so it
+        // matches the raw HTML id in scrollTo's getElementById
+        const target = decodeURIComponent(anchorElementUrl.hash)
 
         this.scrollTo(target, options)
         return
@@ -764,8 +766,11 @@ export class Lenis {
       let node: Element | null = null
 
       if (typeof target === 'string') {
-        // CSS selector
-        node = document.querySelector(target)
+        // getElementById accepts any valid HTML id (e.g. `#footnote-†`),
+        // querySelector would reject it as an invalid CSS selector
+        node = target.startsWith('#')
+          ? document.getElementById(target.slice(1))
+          : document.querySelector(target)
 
         if (!node) {
           if (target === '#top') {

--- a/playground/www/layouts/Layout.astro
+++ b/playground/www/layouts/Layout.astro
@@ -37,6 +37,7 @@ const { title } = Astro.props
       <a href="/horizontal">Horizontal</a>
       <a href="/infinite">Infinite</a>
       <a href="/touch-debug">Touch</a>
+      <a href="/anchor-special-chars">Anchor</a>
     </nav>
     <slot />
   </body>

--- a/playground/www/pages/anchor-special-chars.astro
+++ b/playground/www/pages/anchor-special-chars.astro
@@ -1,0 +1,45 @@
+---
+import Layout from '../layouts/Layout.astro'
+---
+
+<!-- Tests anchor scroll for ids with CSS-special chars (issue #520) -->
+<Layout title="Lenis — Anchor special chars">
+  <nav id="links">
+    <a href="#footnote-†">jump to #footnote-†</a>
+    <a href="#a*b">jump to #a*b</a>
+    <a href="#with space">jump to #with space</a>
+    <a href="#about">jump to #about (plain)</a>
+    <a href="#top">jump to #top</a>
+  </nav>
+
+  <section id="about"><h2>about (plain id)</h2></section>
+  <section id="footnote-†"><h2>id="footnote-†"</h2></section>
+  <section id="a*b"><h2>id="a*b"</h2></section>
+  <section id="with space"><h2>id="with space"</h2></section>
+
+  <script>
+    import Lenis from 'lenis'
+    const lenis = new Lenis({ autoRaf: true, anchors:true })
+    console.log(lenis)
+  </script>
+
+  <style>
+    #links {
+      position: fixed;
+      top: 4rem;
+      left: 2px;
+      flex-direction: column;
+      height: auto;
+    }
+    section {
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: monospace;
+    }
+    section:nth-child(even) {
+      background: #f0f0f0;
+    }
+  </style>
+</Layout>


### PR DESCRIPTION
Fixes #520

## Problem

Anchor scroll failed for element ids containing CSS-special characters (e.g. `#footnote-†`, `#a*b`). Lenis resolved the target via `document.querySelector(target)`, which rejects these as invalid CSS selectors, and the URL-encoded hash (`#footnote-%E2%80%A0`) never matched the raw id — so Lenis bailed out and the browser did its instant native jump instead of a smooth scroll.

## Fix

- `scrollTo`: resolve `#`-prefixed targets via `getElementById`, which accepts any valid HTML id regardless of CSS-special chars (falls back to `querySelector` for non-`#` selectors).
- `onClick` (anchors): `decodeURIComponent` the hash before passing it to `scrollTo` so the encoded `href` matches the real id.

## Test

Added `playground/www/pages/anchor-special-chars.astro` (linked from the playground nav) with anchors targeting `#footnote-†`, `#a*b`, `#with space`, plus plain `#about` / `#top` controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)