### PR TITLE
fix: stop the lenis scroll when autoscroll (mouse3) is pressed

### DIFF
--- a/packages/core/src/lenis.ts
+++ b/packages/core/src/lenis.ts
@@ -35,6 +35,8 @@ export class Lenis {
   private _resetVelocityTimeout: ReturnType<typeof setTimeout> | null = null
   private _rafId: number | null = null
   private _isDraggingSelection = false // true while a touch is dragging an iOS selection handle
+  private _isAutoscrolling = false
+  private _middleClickTime = 0
 
   /**
    * Whether or not the user is touching the screen
@@ -214,6 +216,9 @@ export class Lenis {
       this.onPointerDown as EventListener
     )
 
+    window.addEventListener('pointerup', this.onPointerUp as EventListener)
+    window.addEventListener('keydown', this.onKeyDown as EventListener)
+
     // Setup virtual scroll instance
     this.virtualScroll = new VirtualScroll(eventsTarget as HTMLElement, {
       touchMultiplier,
@@ -247,6 +252,9 @@ export class Lenis {
       'pointerdown',
       this.onPointerDown as EventListener
     )
+
+    window.removeEventListener('pointerup', this.onPointerUp as EventListener)
+    window.removeEventListener('keydown', this.onKeyDown as EventListener)
 
     if (this.options.anchors || this.options.stopInertiaOnNavigate) {
       this.options.wrapper.removeEventListener(
@@ -395,8 +403,29 @@ export class Lenis {
   }
 
   private onPointerDown = (event: PointerEvent | MouseEvent) => {
+    if (this._isAutoscrolling) {
+      this._isAutoscrolling = false
+      return
+    }
+
     if (event.button === 1) {
       this.reset()
+      this._isAutoscrolling = true
+      this._middleClickTime = Date.now()
+    }
+  }
+
+  private onPointerUp = (event: PointerEvent | MouseEvent) => {
+    if (event.button === 1 && this._isAutoscrolling) {
+      if (Date.now() - this._middleClickTime > 300) {
+        this._isAutoscrolling = false
+      }
+    }
+  }
+
+  private onKeyDown = () => {
+    if (this._isAutoscrolling) {
+      this._isAutoscrolling = false
     }
   }
 
@@ -429,6 +458,8 @@ export class Lenis {
   }
 
   private onVirtualScroll = (data: VirtualScrollData) => {
+    if (this._isAutoscrolling) return
+
     if (
       typeof this.options.virtualScroll === 'function' &&
       this.options.virtualScroll(data) === false
@@ -645,6 +676,7 @@ export class Lenis {
   private reset() {
     this.isLocked = false
     this.isScrolling = false
+    this._isAutoscrolling = false
     this.animatedScroll = this.targetScroll = this.actualScroll
     this.lastVelocity = this.velocity = 0
     this.animate.stop()


### PR DESCRIPTION
## What & why

This PR resolves a conflict between native middle-click autoscroll (activated by pressing mouse3) and Lenis smooth wheel scrolling.

**What changes:**
- Adds private tracking fields (`_isAutoscrolling` and `_middleClickTime`) to track the browser's native autoscroll lifecycle.
- Binds `pointerup` and `keydown` event listeners to the `window` to detect when autoscrolling ends.
- Returns early from `onVirtualScroll` when `_isAutoscrolling` is active, ignoring virtual scroll events (e.g., mouse wheel events) while autoscrolling.
- Resets the `_isAutoscrolling` state back to `false` when calling `reset()`.

**Why it's needed:**
When a user starts autoscrolling by middle-clicking while a previous mouse wheel smooth scroll animation is still running (or scrolls the wheel during autoscroll), the native browser scroll and the Lenis scroll engine have a conflict. This causes jitter and unexpected scroll behavior. Disabling virtual scroll during autoscrolling lets the browser handle native scrolling smoothly without conflicts.

Closes #528

## How to verify

1. Clone/pull the branch and run the playground locally using `bun run dev`.
2. Scroll the page using the mouse wheel, then immediately middle-click to enter autoscroll and move the mouse around.
3. Observe that the scroll is smooth and doesn't jitter or jump back to the previous target.
4. Scroll the wheel while autoscrolling is active and verify that it doesn't conflict or trigger smooth scroll animations.

### Demo

BEFORE FIX

https://github.com/user-attachments/assets/3bdccb8b-941c-4dd2-aa51-3109423f62c7

AFTER FIX

https://github.com/user-attachments/assets/00c887fa-1f07-4ee2-8df1-a565b679c386

## Checklist

- [x] PR is focused on a single logical change
- [x] Linked the related issue (or explained why there isn't one)
- [x] Lint/format/tests pass locally
- [x] Updated docs/types where relevant
