### PR TITLE
feat(core): detect middle-click autoscroll and yield wheel events (#528)

### DIFF
--- a/packages/core/src/auto-scroll-detection.ts
+++ b/packages/core/src/auto-scroll-detection.ts
@@ -19,17 +19,19 @@ export class AutoScrollDetection {
 
     this.wrapper.addEventListener('pointerdown', this.onPointerDown)
     this.wrapper.addEventListener('pointerup', this.onPointerUp)
-    window.addEventListener('blur', this.onBlur)
+    window.addEventListener('blur', this.reset)
+    window.addEventListener('keydown', this.reset)
   }
 
   destroy() {
     this.wrapper.removeEventListener('pointerdown', this.onPointerDown)
     this.wrapper.removeEventListener('pointerup', this.onPointerUp)
-    window.removeEventListener('blur', this.onBlur)
+    window.removeEventListener('blur', this.reset)
+    window.removeEventListener('keydown', this.reset)
     this.emitter.destroy()
   }
 
-  private onBlur = () => {
+  private reset = () => {
     this.phase = 0
   }
 

--- a/packages/core/src/auto-scroll-detection.ts
+++ b/packages/core/src/auto-scroll-detection.ts
@@ -1,0 +1,91 @@
+// phase 0: initial state
+// phase 1: middle pointerdown // autoscroll started
+// phase 2: pointerup // sticky autoscroll continues
+// phase 3: pointerup (any button) // autoscroll stops
+
+import { Emitter } from './emitter'
+
+export class AutoScrollDetection {
+  private _phase = 0
+  private _isEnabled = false
+  private readonly emitter = new Emitter()
+
+  constructor(private readonly wrapper: HTMLElement) {
+    // native middle-click autoscroll only exists in Blink on Windows.
+    // "Chrome" matches all Chromium browsers (Edge/Brave/Opera keep the
+    // token) but not Firefox/Safari
+    const ua = navigator.userAgent
+    if (!(/Windows/.test(ua) && /Chrome/.test(ua))) return
+
+    this.wrapper.addEventListener('pointerdown', this.onPointerDown)
+    this.wrapper.addEventListener('pointerup', this.onPointerUp)
+    window.addEventListener('blur', this.onBlur)
+  }
+
+  destroy() {
+    this.wrapper.removeEventListener('pointerdown', this.onPointerDown)
+    this.wrapper.removeEventListener('pointerup', this.onPointerUp)
+    window.removeEventListener('blur', this.onBlur)
+    this.emitter.destroy()
+  }
+
+  private onBlur = () => {
+    this.phase = 0
+  }
+
+  private onPointerDown = (event: PointerEvent) => {
+    // while sticky autoscroll is active, this click is the exit click —
+    // keep phase 2 so its pointerup resolves to phase 3
+    if (this.phase === 2) return
+
+    if (event.button !== 1) return
+
+    // middle-click on a link opens a tab, no autoscroll starts
+    const isLinkClick = event
+      .composedPath()
+      .some((target) => target instanceof HTMLElement && target.tagName === 'A')
+    if (isLinkClick) return
+
+    this.phase = 1
+  }
+
+  private onPointerUp = (event: PointerEvent) => {
+    if (this.phase === 1 && event.button === 1) {
+      this.phase = 2
+    } else if (this.phase === 2) {
+      // any button exits sticky autoscroll, not just middle
+      this.phase = 3
+    }
+  }
+
+  private set phase(value: number) {
+    if (value === this._phase) return
+
+    this._phase = value
+
+    this.isEnabled = value === 1 || value === 2
+  }
+
+  private get phase() {
+    return this._phase
+  }
+
+  get isEnabled() {
+    return this._isEnabled
+  }
+
+  private set isEnabled(value: boolean) {
+    if (value === this._isEnabled) return
+
+    this._isEnabled = value
+    this.emitter.emit('toggle')
+  }
+
+  on(event: 'toggle', callback: () => void): () => void {
+    return this.emitter.on(event, callback)
+  }
+
+  off(event: 'toggle', callback: () => void): void {
+    this.emitter.off(event, callback)
+  }
+}

--- a/packages/core/src/lenis.ts
+++ b/packages/core/src/lenis.ts
@@ -1,5 +1,6 @@
 import { version } from '../../../package.json'
 import { Animate } from './animate'
+import { AutoScrollDetection } from './auto-scroll-detection'
 import { Dimensions } from './dimensions'
 import { Emitter } from './emitter'
 import { clamp, modulo } from './maths'
@@ -101,6 +102,7 @@ export class Lenis {
   // These are instanciated in the constructor as they need information from the options
   readonly dimensions: Dimensions // This is not private because it's used in the Snap class
   private readonly virtualScroll: VirtualScroll
+  private readonly autoScrollDetection: AutoScrollDetection
 
   constructor({
     wrapper = window,
@@ -215,10 +217,10 @@ export class Lenis {
       )
     }
 
-    this.options.wrapper.addEventListener(
-      'pointerdown',
-      this.onPointerDown as EventListener
+    this.autoScrollDetection = new AutoScrollDetection(
+      this.options.wrapper as HTMLElement
     )
+    this.autoScrollDetection.on('toggle', () => this.reset())
 
     // Setup virtual scroll instance
     this.virtualScroll = new VirtualScroll(eventsTarget as HTMLElement, {
@@ -249,10 +251,7 @@ export class Lenis {
       capture: true,
     })
 
-    this.options.wrapper.removeEventListener(
-      'pointerdown',
-      this.onPointerDown as EventListener
-    )
+    this.autoScrollDetection.destroy()
 
     if (this.options.anchors || this.options.stopInertiaOnNavigate) {
       this.options.wrapper.removeEventListener(
@@ -400,12 +399,6 @@ export class Lenis {
     }
   }
 
-  private onPointerDown = (event: PointerEvent | MouseEvent) => {
-    if (event.button === 1) {
-      this.reset()
-    }
-  }
-
   // iOS renders text-selection handles at the start and end points of the
   // selection. A touch starting within a handle-sized radius of either point is
   // the user grabbing a handle, not scrolling.
@@ -452,6 +445,12 @@ export class Lenis {
 
     const isTouch = event.type.includes('touch')
     const isWheel = event.type.includes('wheel')
+
+    // wheel events during the browser's middle-click autoscroll would fight
+    // the native scrolling, let the browser handle them instead (#528).
+    if (isWheel && this.autoScrollDetection.isEnabled) {
+      return
+    }
 
     // If the touch grabbed an iOS text-selection handle, let the OS adjust the
     // selection instead of scrolling. Latched on touchstart, held until touchend.

--- a/playground/core/test.ts
+++ b/playground/core/test.ts
@@ -128,6 +128,9 @@ const renderDebug = (e: Lenis) => {
 }
 
 lenis.on('scroll', renderDebug)
+lenis.on('scroll', (lenis) => {
+  console.log(lenis.isScrolling)
+})
 window.addEventListener('scroll', () => renderDebug(lenis), { passive: true })
 
 // document.querySelectorAll('a[href*="#"]').forEach((node) => {


### PR DESCRIPTION
## Summary

Follow-up to #528 (wheel vs middle-click autoscroll jitter). Replaces the bare reset-on-middle-click with an `AutoScrollDetection` class that tracks the browser's native autoscroll lifecycle, so lenis can stop smoothing wheel events while native autoscroll is driving the scroll.

- **Phase state machine**: middle `pointerdown` starts autoscroll (phase 1), its `pointerup` latches sticky mode (phase 2), and the next click's `pointerup` — any button — exits (phase 3). While phases 1–2 are active, `onVirtualScroll` ignores wheel events and lets the browser handle them.
- **`toggle` event** fires on enter/exit and resets lenis's animated scroll state, replacing the previous unconditional reset on middle `pointerdown`.
- **Keydown/blur escape hatches**: any `keydown` resets detection to idle — keyboard input exits native autoscroll in Chromium — and so does window `blur`, since after a focus loss the state can't be trusted. Both keep the flag from going stale and silently disabling wheel smoothing.
- **Chromium-on-Windows only**: native middle-click autoscroll only ships enabled in Blink on Windows, so detection doesn't attach anywhere else (`Windows` + `Chrome` UA check — Edge/Brave/Opera keep the `Chrome` token; Firefox/Safari don't match). Prevents the flag from going stale on platforms where the pointer events fire but no autoscroll follows.
- **Link guard**: middle-click on an `<a>` opens a tab instead of autoscrolling, so it doesn't arm the flag.

## Test plan

- [x] Real middle-click on Windows Chrome: sticky autoscroll, then wheel — no fighting/jitter, exit click restores smoothing
- [ ] Drag-mode autoscroll (hold middle + drag), release, then wheel
- [ ] Press a key during sticky autoscroll — autoscroll exits and wheel smoothing is restored
- [ ] Middle-click on a link: new tab opens, wheel smoothing unaffected
- [ ] Alt-tab away during sticky autoscroll, come back, wheel smoothing restored
- [ ] macOS/Firefox: middle-click leaves wheel smoothing untouched

Native autoscroll can't be triggered synthetically (CDP/dispatched events), so this needs real hardware verification on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)