### PR TITLE
fix: detect precision touchpad and bypass lerp for responsive scroll

### DIFF
--- a/packages/core/src/lenis.ts
+++ b/packages/core/src/lenis.ts
@@ -441,7 +441,7 @@ export class Lenis {
     )
       return
 
-    const { deltaX, deltaY, event } = data
+    const { deltaX, deltaY, event, isPrecisionTouchpad } = data
 
     this.emitter.emit('virtual-scroll', { deltaX, deltaY, event })
 
@@ -590,11 +590,15 @@ export class Lenis {
         ? {
             lerp: hasTouchInertia ? this.options.syncTouchLerp : 1,
           }
-        : {
-            lerp: this.options.lerp,
-            duration: this.options.duration,
-            easing: this.options.easing,
-          }),
+        : isPrecisionTouchpad
+          ? {
+              lerp: 1,
+            }
+          : {
+              lerp: this.options.lerp,
+              duration: this.options.duration,
+              easing: this.options.easing,
+            }),
     })
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,6 +41,7 @@ export type VirtualScrollData = {
   deltaX: number
   deltaY: number
   event: WheelEvent | TouchEvent
+  isPrecisionTouchpad?: boolean
 }
 
 export type Orientation = 'vertical' | 'horizontal'

--- a/packages/core/src/virtual-scroll.ts
+++ b/packages/core/src/virtual-scroll.ts
@@ -24,6 +24,9 @@ export class VirtualScroll {
     height: 0,
   }
   private emitter = new Emitter()
+  private lastWheelTime = 0
+  private rapidWheelCount = 0
+  isPrecisionTouchpad = false
 
   constructor(
     private element: HTMLElement,
@@ -152,7 +155,33 @@ export class VirtualScroll {
     deltaX *= this.options.wheelMultiplier
     deltaY *= this.options.wheelMultiplier
 
-    this.emitter.emit('scroll', { deltaX, deltaY, event })
+    // Detect precision touchpad: pixel-mode events arriving rapidly with small deltas
+    if (deltaMode === 0) {
+      const now = performance.now()
+      const elapsed = now - this.lastWheelTime
+      const maxDelta = Math.max(Math.abs(event.deltaX), Math.abs(event.deltaY))
+
+      if (elapsed < 100 && maxDelta < 50) {
+        this.rapidWheelCount++
+        if (this.rapidWheelCount >= 2) {
+          this.isPrecisionTouchpad = true
+        }
+      } else if (elapsed >= 100) {
+        this.rapidWheelCount = 0
+        this.isPrecisionTouchpad = false
+      }
+
+      this.lastWheelTime = now
+    } else {
+      this.isPrecisionTouchpad = false
+    }
+
+    this.emitter.emit('scroll', {
+      deltaX,
+      deltaY,
+      event,
+      isPrecisionTouchpad: this.isPrecisionTouchpad,
+    })
   }
 
   onWindowResize = () => {


### PR DESCRIPTION
## Problem

Precision touchpads on 2-in-1 tablets (e.g. Surface Go 3) produce `wheel` events with small pixel-mode deltas (1–10px) at high frequency (~8ms intervals), unlike regular mouse wheels which produce large deltas (100–120px per notch).

Lenis applies `lerp: 0.1` smoothing uniformly to all wheel events. With a 3px precision touchpad delta, first frame moves only 0.3px — subpixel and imperceptible — causing severe scroll lag. The animation can't keep up with the continuous input stream.

Fixes #215

## Solution

**Detect precision touchpad input** in `VirtualScroll.onWheel` by tracking rapid consecutive wheel events with small pixel-mode deltas:
- `deltaMode === 0` (pixel mode)
- Events arriving within 100ms of each other
- Max delta magnitude < 50px
- 2+ consecutive events matching → `isPrecisionTouchpad = true`
- Resets when event gap exceeds 100ms (user switches to mouse or stops scrolling)

**Bypass lerp smoothing** in `Lenis.onVirtualScroll` when precision touchpad is detected — use `lerp: 1` for direct 1:1 tracking. This mirrors how `syncTouch` handles active finger tracking, since precision touchpad input is already continuous and smooth (like touch input).

## Changes

| File | Change |
|------|--------|
| `packages/core/src/virtual-scroll.ts` | Added precision touchpad detection heuristic in `onWheel` |
| `packages/core/src/types.ts` | Added optional `isPrecisionTouchpad` to `VirtualScrollData` |
| `packages/core/src/lenis.ts` | Adaptive lerp: `1` for precision touchpad, default for mouse wheel |

## Why this approach

- **No new options needed** — works automatically without user configuration
- **Backwards compatible** — `isPrecisionTouchpad` is an optional field; mouse wheel behavior is unchanged
- **Consistent with existing patterns** — uses the same `lerp: 1` technique as `syncTouch` active tracking
- **Self-correcting** — resets detection after 100ms gap, so switching between mouse and touchpad works correctly
- **Threshold safety** — regular mouse wheels produce 100–120px deltas per notch, well above the 50px threshold; even with "1 line at a time" Windows settings (~33px), the frequency check prevents false positives

## Test plan

- [x] `bun run build` passes with zero errors
- [ ] Manual test on Surface Go 3 or similar 2-in-1 with precision touchpad
- [ ] Verify regular mouse wheel scroll behavior is unchanged
- [ ] Verify macOS trackpad behavior is unchanged (macOS trackpads use touch events, not wheel)