### PR TITLE
docs: fix inverted `direction` property values in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ That's it, your page now has smooth scrolling and should handle most of the usua
 | `animatedScroll`        | `number`          | Current scroll value                                                       |
 | `className` (getter)    | `string`          | `rootElement` className                                                    |
 | `dimensions`            | `object`          | Dimensions instance                                                        |
-| `direction`             | `number`          | `1`: scrolling up, `-1`: scrolling down                                    |
+| `direction`             | `number`          | `1`: scrolling down, `-1`: scrolling up                                    |
 | `isHorizontal` (getter) | `boolean`         | Whether or not the instance is horizontal                                  |
 | `isScrolling` (getter)  | `boolean, string` | Whether or not the scroll is being animated, `smooth`, `native` or `false` |
 | `isStopped` (getter)    | `boolean`         | Whether or not the user should be able to scroll                           |


### PR DESCRIPTION
The Properties table describes `direction` as `1`: scrolling up, `-1`: scrolling down, but the implementation computes it as the sign of the scroll delta:

https://github.com/darkroomengineering/lenis/blob/main/packages/core/src/lenis.ts#L630-L632

```ts
this.direction = Math.sign(
  this.animatedScroll - lastScroll
) as Lenis['direction']
```

Scrolling **down** increases the scroll value, so `direction` is `1` when scrolling down and `-1` when scrolling up. This PR flips the two values in the table to match the implementation.